### PR TITLE
Fix all occurances of backslash with OS-agnostic path handling

### DIFF
--- a/bxm/importer/sarImportOperator.py
+++ b/bxm/importer/sarImportOperator.py
@@ -34,7 +34,7 @@ class ImportNierSar(bpy.types.Operator, ImportHelper):
             for root, dirs, files in os.walk(directory):
                 for file in files:
                     if file.endswith(".sar"):
-                        self.doImport(root + '\\' + file)
+                        self.doImport(os.path.join(root, file))
             print("Imported all file!")
         else:
             self.doImport(self.filepath)

--- a/dat_dtt/importer/datImportOperator.py
+++ b/dat_dtt/importer/datImportOperator.py
@@ -14,19 +14,19 @@ def importDat(only_extract, filepath):
     head = os.path.split(filepath)[0]
     tail = os.path.split(filepath)[1]
     tailless_tail = tail[:-4]
-    dat_filepath = head + '\\' + tailless_tail + '.dat'
-    extract_dir = head + '\\nier2blender_extracted'
+    dat_filepath = os.path.join(head, tailless_tail + '.dat')
+    extract_dir = os.path.join(head + 'nier2blender_extracted')
     from . import dat_unpacker
     if os.path.isfile(dat_filepath):
-        dat_unpacker.main(dat_filepath, extract_dir + '\\' + tailless_tail + '.dat', dat_filepath)   # dat
+        dat_unpacker.main(dat_filepath, os.path.join(extract_dir, tailless_tail + '.dat'), dat_filepath)   # dat
     else:
         print('DAT not found. Only extracting DTT. (No materials, collisions or layouts will automatically be imported)')
 
-    last_filename = dat_unpacker.main(filepath, extract_dir + '\\' + tailless_tail + '.dtt', filepath)       # dtt
+    last_filename = dat_unpacker.main(filepath, os.path.join(extract_dir, tailless_tail + '.dtt'), filepath)       # dtt
 
-    wmb_filepath = extract_dir + '\\' + tailless_tail + '.dtt\\' + last_filename[:-4] + '.wmb'
+    wmb_filepath = os.path.join(extract_dir, tailless_tail + '.dtt', last_filename[:-4] + '.wmb')
     if not os.path.exists(wmb_filepath):
-        wmb_filepath = extract_dir + '\\' + tailless_tail + '.dat\\' + last_filename[:-4] + '.wmb'                     # if not in dtt, then must be in dat
+        wmb_filepath = os.path.join(extract_dir, tailless_tail + '.dat', last_filename[:-4] + '.wmb')                     # if not in dtt, then must be in dat
 
     # WMB
     from ...wmb.importer import wmb_importer
@@ -39,14 +39,14 @@ def importDat(only_extract, filepath):
     enableVisibilitySelector()
 
     # COL
-    col_filepath = extract_dir + '\\' + tailless_tail + '.dat\\' + tailless_tail + '.col'
+    col_filepath = os.path.join(extract_dir, tailless_tail + '.dat', tailless_tail + '.col')
     if os.path.isfile(col_filepath):
         from ...col.importer import col_importer
         col_importer.main(col_filepath)
         enableCollisionTools()
 
     # LAY
-    lay_filepath = extract_dir + '\\' + tailless_tail + '.dat\\' + 'Layout.lay'
+    lay_filepath = os.path.join(extract_dir, tailless_tail + '.dat', 'Layout.lay')
     if os.path.isfile(lay_filepath):
         from ...lay.importer import lay_importer
         lay_importer.main(lay_filepath, ADDON_NAME)
@@ -74,7 +74,7 @@ class ImportNierDtt(bpy.types.Operator, ImportHelper):
             for filename in os.listdir(folder):
                 if filename[-4:] == '.dtt':
                     try:
-                        filepath = folder + '\\' + filename
+                        filepath = os.path.join(folder, filename)
                         importDat(self.only_extract, filepath)
                     except:
                         print('ERROR: FAILED TO IMPORT', filename)
@@ -99,11 +99,11 @@ class ImportNierDat(bpy.types.Operator, ImportHelper):
         head = os.path.split(filepath)[0]
         tail = os.path.split(filepath)[1]
         tailless_tail = tail[:-4]
-        dat_filepath = head + '\\' + tailless_tail + '.dat'
-        extract_dir = head + '\\nier2blender_extracted'
+        dat_filepath = os.path.join(head, tailless_tail + '.dat')
+        extract_dir = os.path.join(head, 'nier2blender_extracted')
         from . import dat_unpacker
         if os.path.isfile(dat_filepath):
-            dat_unpacker.main(dat_filepath, extract_dir + '\\' + tailless_tail + '.dat', dat_filepath)   # dat
+            dat_unpacker.main(dat_filepath, os.path.join(extract_dir, tailless_tail + '.dat'), dat_filepath)   # dat
 
         if onlyExtract:
             return {'FINISHED'}
@@ -111,14 +111,14 @@ class ImportNierDat(bpy.types.Operator, ImportHelper):
         setExportFieldsFromImportFile(filepath)
 
         # COL
-        col_filepath = extract_dir + '\\' + tailless_tail + '.dat\\' + tailless_tail + '.col'
+        col_filepath = os.path.join(extract_dir, tailless_tail + '.dat', tailless_tail + '.col')
         if os.path.isfile(col_filepath):
             from ...col.importer import col_importer
             col_importer.main(col_filepath)
             enableCollisionTools()
 
         # LAY
-        lay_filepath = extract_dir + '\\' + tailless_tail + '.dat\\' + 'Layout.lay'
+        lay_filepath = os.path.join(extract_dir, tailless_tail + '.dat', 'Layout.lay')
         if os.path.isfile(lay_filepath):
             from ...lay.importer import lay_importer
             lay_importer.main(lay_filepath, ADDON_NAME)
@@ -134,7 +134,7 @@ class ImportNierDat(bpy.types.Operator, ImportHelper):
             for filename in os.listdir(folder):
                 if filename[-4:] == '.dat':
                     try:
-                        filepath = folder + '\\' + filename
+                        filepath = os.path.join(folder, filename)
                         self.doImport(self.only_extract, filepath)
                     except:
                         print('ERROR: FAILED TO IMPORT', filename)

--- a/dat_dtt/importer/dat_unpacker.py
+++ b/dat_dtt/importer/dat_unpacker.py
@@ -99,7 +99,7 @@ def extract_hashes(fp, extract_dir, FileCount, hashMapOffset, fileNamesOffset):
 
 	# Extraction
 	filename = 'file_order.metadata'
-	extract_dir_sub = extract_dir + '\\' + filename
+	extract_dir_sub = os.path.join(extract_dir, filename)
 	with open(extract_dir_sub,'wb') as outfile:
 
 		# Header
@@ -138,7 +138,7 @@ def extract_hashes(fp, extract_dir, FileCount, hashMapOffset, fileNamesOffset):
  
 	# Extraction
 	filename = 'hash_data.metadata'
-	extract_dir_sub = extract_dir + '\\' + filename
+	extract_dir_sub = os.path.join(extract_dir, filename)
 	with open(extract_dir_sub,'wb') as outfile:
 
 			# Header
@@ -172,7 +172,7 @@ def main(filename, extract_dir, ROOT_DIR):
 				extract_dir_sub = ''
 				index,Filename,FileOffset,Size,Extension = get_fileinfo(fp, i, FileTableOffset,ExtensionTableOffset, NameTableOffset,SizeTableOffset)
 				if extract_dir != '':
-					extract_dir_sub = extract_dir + '\\' + filename.replace(ROOT_DIR ,'') 
+					extract_dir_sub = os.path.join(extract_dir, filename.replace(ROOT_DIR ,''))
 					extract_file(fp, Filename, FileOffset, Size, extract_dir_sub)
 			
 			extract_hashes(fp, extract_dir, FileCount, hashMapOffset, NameTableOffset)
@@ -204,5 +204,5 @@ if __name__ == '__main__':
 	ROOT_DIR = dir_name
 	for dirpath,dirnames,filename in os.walk(dir_name):
 		for file in filename:
-			filename = "%s\%s"%(dirpath,file)
+			filename = os.path.join(dirpath,file)
 			main(filename, extract_dir, ROOT_DIR)

--- a/utils/util.py
+++ b/utils/util.py
@@ -179,10 +179,10 @@ def setExportFieldsFromImportFile(filepath: str) -> None:
     head = os.path.split(filepath)[0]
     tail = os.path.split(filepath)[1]
     tailless_tail = tail[:-4]
-    extract_dir = head + '\\nier2blender_extracted'
+    extract_dir = os.path.join(head, 'nier2blender_extracted')
 
-    bpy.context.scene.DatDir = extract_dir + '\\' + tailless_tail + '.dat'
-    bpy.context.scene.DttDir = extract_dir + '\\' + tailless_tail + '.dtt'
+    bpy.context.scene.DatDir = os.path.join(extract_dir, tailless_tail + '.dat')
+    bpy.context.scene.DttDir = os.path.join(extract_dir, tailless_tail + '.dtt')
     bpy.context.scene.ExportFileName = tailless_tail
 
 def getPreferences():

--- a/wmb/importer/wmb.py
+++ b/wmb/importer/wmb.py
@@ -394,9 +394,9 @@ class wmb3_material(object):
 		self.techniqueName = to_string(wmb_fp.read(256))
 		self.textureArray = {}
 
-		path_split = wmb_fp.name.split('\\')
-		mat_list_filepath = "\\".join(path_split[:-3])
-		mat_list_file = open(mat_list_filepath + '\\materials.json', 'a+')
+		path_split = wmb_fp.name.split(os.sep)
+		mat_list_filepath = os.sep.join(path_split[:-3])
+		mat_list_file = open(os.path.join(mat_list_filepath, 'materials.json'), 'a+')
 		mat_list_file.seek(0)
 		file_dict = {}
 		# Try to load json from pre-existing file
@@ -836,7 +836,7 @@ def main(arg, wmb_fp, wta_fp, wtp_fp, dump):
 		wta = WTA(wta_fp)
 		wta_fp.close()
 	if dump:
-		obj_file = arg.split('\\')[-1].replace('.wmb','')
+		obj_file = os.path.split(arg)[-1].replace('.wmb','')
 		export_obj(wmb, wta, wtp_fp, obj_file)
 		if wtp_fp:
 			wtp_fp.close()

--- a/wmb/importer/wmb_importer.py
+++ b/wmb/importer/wmb_importer.py
@@ -572,9 +572,9 @@ def get_wmb_material(wmb, texture_dir):
 					try:
 						texture_stream = wmb.wta.getTextureByIdentifier(identifier,wmb.wtp_fp)
 						if texture_stream:
-							if not os.path.exists("%s\%s.dds" %(texture_dir, identifier)):
+							if not os.path.exists(os.path.join(texture_dir, identifier + '.dds')):
 								create_dir(texture_dir)
-								texture_fp = open("%s\%s.dds" %(texture_dir, identifier), "wb")
+								texture_fp = open(os.path.join(texture_dir, identifier + '.dds'), "wb")
 								print('[+] dumping %s.dds'% identifier)
 								texture_fp.write(texture_stream)
 								texture_fp.close()
@@ -588,9 +588,9 @@ def get_wmb_material(wmb, texture_dir):
 				identifier = wmb.wta.wtaTextureIdentifier[textureIndex]
 				texture_stream = wmb.wta.getTextureByIdentifier(identifier,wmb.wtp_fp)
 				if texture_stream:
-					if not os.path.exists("%s\%s.dds" %(texture_dir, identifier)):
+					if not os.path.exists(os.path.join(texture_dir, identifier + '.dds')):
 						create_dir(texture_dir)
-						texture_fp = open("%s\%s.dds" %(texture_dir, identifier), "wb")
+						texture_fp = open(os.path.join(texture_dir, identifier + '.dds'), "wb")
 						print('[+] dumping %s.dds'% identifier)
 						texture_fp.write(texture_stream)
 						texture_fp.close()
@@ -656,13 +656,13 @@ def import_unknowWorldDataArray(wmb):
 		unknownWorldDataDict[unknownWorldDataName] = unknownWorldData.unknownWorldData
 	bpy.context.scene['unknownWorldData'] = unknownWorldDataDict
 
-def main(only_extract = False, wmb_file = os.path.split(os.path.realpath(__file__))[0] + '\\test\\pl0000.dtt\\pl0000.wmb'):
+def main(only_extract = False, wmb_file = os.path.join(os.path.split(os.path.realpath(__file__))[0], 'test', 'pl0000.dtt', 'pl0000.wmb')):
 	#reset_blend()
 	wmb = WMB3(wmb_file, only_extract)
-	wmbname = wmb_file.split('\\')[-1]
+	wmbname = os.path.split(wmb_file)[-1] # Split only splits into head and tail, but since we want the last part, we don't need to split the head with wmb_file.split(os.sep)
 
 	if only_extract:
-		texture_dir = wmb_file.replace(wmbname, '\\textures\\')
+		texture_dir = wmb_file.replace(wmbname, '%stextures%s'.format(os.sep, os.sep))
 		wmb_materials = get_wmb_material(wmb, texture_dir)
 		print('Extraction finished. ;)')
 		return {'FINISHED'}
@@ -678,7 +678,7 @@ def main(only_extract = False, wmb_file = os.path.split(os.path.realpath(__file_
 	wmbCollection.children.link(col)
 	#bpy.context.view_layer.active_layer_collection = bpy.context.view_layer.layer_collection.children[-1]
 	
-	texture_dir = wmb_file.replace(wmbname, '\\textures\\')
+	texture_dir = wmb_file.replace(wmbname, '%stextures%s'.format(os.sep, os.sep))
 	if wmb.hasBone:
 		boneArray = [[bone.boneIndex, "bone%d"%bone.boneIndex, bone.parentIndex,"bone%d"%bone.parentIndex, bone.world_position, bone.world_rotation, bone.boneNumber, bone.local_position, bone.local_rotation, bone.world_rotation, bone.world_position_tpose] for bone in wmb.boneArray]
 		armature_no_wmb = wmbname.replace('.wmb','')

--- a/xmlScripting/importer/yaxXmlImportOperator.py
+++ b/xmlScripting/importer/yaxXmlImportOperator.py
@@ -31,7 +31,7 @@ class ImportNierYaxXml(bpy.types.Operator, ImportHelper):
             for root, dirs, files in os.walk(directory):
                 for file in files:
                     if file.endswith(".xml"):
-                        self.doImport(root + '\\' + file)
+                        self.doImport(os.path.join(root, file))
             print("Imported all files!")
         else:
             self.doImport(self.filepath)


### PR DESCRIPTION
Because the importer doesn't work in Linux (tested in Kubuntu22.04), I have taken a look through the repo and changed every bit where file paths were generated with hardcoded backslashes to OS independant `os.path.join` calls, mostly.

It works in Linux now, though I don't know the state of things in Windows. Should work though, hopefully.