### PR TITLE
Ignore unused vertex groups on Meshes

### DIFF
--- a/utils/util.py
+++ b/utils/util.py
@@ -100,12 +100,9 @@ def getAllBonesInOrder(collectionName):
             return list(obj.data.bones)
 
 def getBoneIndexByName(collectionName, name):
-    try:
-        for i, bone in enumerate(getAllBonesInOrder(collectionName)):
-            if bone.name == name:
-                return i
-    except:
-        pass
+    for i, bone in enumerate(getAllBonesInOrder(collectionName)):
+        if bone.name == name:
+            return i
 
 def create_dir(dirpath):
     if not os.path.exists(dirpath):

--- a/utils/util.py
+++ b/utils/util.py
@@ -100,9 +100,12 @@ def getAllBonesInOrder(collectionName):
             return list(obj.data.bones)
 
 def getBoneIndexByName(collectionName, name):
-    for i, bone in enumerate(getAllBonesInOrder(collectionName)):
-        if bone.name == name:
-            return i
+    try:
+        for i, bone in enumerate(getAllBonesInOrder(collectionName)):
+            if bone.name == name:
+                return i
+    except:
+        pass
 
 def create_dir(dirpath):
     if not os.path.exists(dirpath):

--- a/wmb/exporter/boneSet/boneSet.py
+++ b/wmb/exporter/boneSet/boneSet.py
@@ -1,6 +1,6 @@
 import bpy
 from ....utils.util import getBoneIndexByName
-
+import time
 class c_boneSet(object):
     def __init__(self, boneMap, boneSets_Offset):
 
@@ -71,13 +71,10 @@ class c_b_boneSets(object):
                 vertex_group_bones = []
                 if obj['boneSetIndex'] != -1:
                     for group in obj.vertex_groups:
-                        print(group.name)
-                        try:
-                            boneID = getBoneIndexByName("WMB", group.name)
+                        boneID = getBoneIndexByName("WMB", group.name)
+                        if boneID:
                             boneMapIndex = boneMap.index(boneID)
                             vertex_group_bones.append(boneMapIndex)
-                        except:
-                            pass
                         
                     if vertex_group_bones not in b_boneSets:
                         b_boneSets.append(vertex_group_bones)

--- a/wmb/exporter/boneSet/boneSet.py
+++ b/wmb/exporter/boneSet/boneSet.py
@@ -1,6 +1,6 @@
 import bpy
 from ....utils.util import getBoneIndexByName
-
+import time
 class c_boneSet(object):
     def __init__(self, boneMap, boneSets_Offset):
 
@@ -53,8 +53,9 @@ class c_b_boneSets(object):
                 for group in obj.vertex_groups:
                     boneID = getBoneIndexByName("WMB", group.name)
                     if boneID not in boneMap:
-                        #print("Adding ID to boneMap: " + str(boneID))
-                        boneMap.append(boneID)
+                        print("Adding ID to boneMap: " + str(boneID))
+                        if not str(boneID) == 'None':
+                            boneMap.append(boneID)
 
         # Set boneMap to armature
         boneMap = sorted(boneMap)
@@ -70,9 +71,14 @@ class c_b_boneSets(object):
                 vertex_group_bones = []
                 if obj['boneSetIndex'] != -1:
                     for group in obj.vertex_groups:
-                        boneID = getBoneIndexByName("WMB", group.name)
-                        boneMapIndex = boneMap.index(boneID)
-                        vertex_group_bones.append(boneMapIndex)
+                        print(group.name)
+                        try:
+                            boneID = getBoneIndexByName("WMB", group.name)
+                            boneMapIndex = boneMap.index(boneID)
+                            vertex_group_bones.append(boneMapIndex)
+                        except:
+                            pass
+                        
                     if vertex_group_bones not in b_boneSets:
                         b_boneSets.append(vertex_group_bones)
                         obj["boneSetIndex"] = len(b_boneSets)-1

--- a/wmb/exporter/boneSet/boneSet.py
+++ b/wmb/exporter/boneSet/boneSet.py
@@ -1,6 +1,6 @@
 import bpy
 from ....utils.util import getBoneIndexByName
-import time
+
 class c_boneSet(object):
     def __init__(self, boneMap, boneSets_Offset):
 

--- a/wmb/exporter/meshes/mesh.py
+++ b/wmb/exporter/meshes/mesh.py
@@ -63,8 +63,9 @@ class c_mesh(object):
                     for vertexGroup in mesh.vertex_groups:
                         boneName = getBoneIndexByName("WMB", vertexGroup.name)
                         if boneName not in bones:
-                            bones.append(boneName)
-                            numBones += 1
+                            if type(boneName) == int:
+                                bones.append(boneName)
+                                numBones += 1
             if len(bones) == 0:
                 bones.append(0)
 


### PR DESCRIPTION
a couple edits to ignore the unused vertex groups on mehses instead of returning an error.