### PR TITLE
Allow for empty mesh exports

### DIFF
--- a/wmb/exporter/vertexGroups/vertexGroup.py
+++ b/wmb/exporter/vertexGroups/vertexGroup.py
@@ -16,7 +16,8 @@ class c_vertexGroup(object):
                     if int(obj_name[-1]) == vertexGroupIndex:
                         if len(obj.data.uv_layers) == 0:
                             obj.data.uv_layers.new()
-                        obj.data.calc_tangents()
+                        if len(obj.data.loops) > 0:
+                            obj.data.calc_tangents()
                         objs[int(obj_name[0])] = obj
 
             blenderObjects = []


### PR DESCRIPTION
When attempting to export a file that had an empty mesh within it, I encountered the following error:

```
Traceback (most recent call last):
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\NieR2Blender2NieR-master\wmb\exporter\wmbExportOperator.py", line 45, in execute
    wmb_exporter.main(self.filepath)
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\NieR2Blender2NieR-master\wmb\exporter\wmb_exporter.py", line 43, in main
    generated_data = c_generate_data()
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\NieR2Blender2NieR-master\wmb\exporter\generate_data.py", line 72, in __init__
    self.vertexGroups = c_vertexGroups(self.vertexGroups_Offset)
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\NieR2Blender2NieR-master\wmb\exporter\vertexGroups\create_vertexGroups.py", line 31, in __init__
    self.vertexGroups = get_vertexGroups(self, self.offsetVertexGroups)
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\NieR2Blender2NieR-master\wmb\exporter\vertexGroups\create_vertexGroups.py", line 27, in get_vertexGroups
    vertexGroups.append(c_vertexGroup(index, vertexesOffset))
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\NieR2Blender2NieR-master\wmb\exporter\vertexGroups\vertexGroup.py", line 28, in __init__
    self.blenderObjects = get_blenderObjects(self)
  File "C:\Users\user\AppData\Roaming\Blender Foundation\Blender\3.2\scripts\addons\NieR2Blender2NieR-master\wmb\exporter\vertexGroups\vertexGroup.py", line 19, in get_blenderObjects
    obj.data.calc_tangents()
RuntimeError: Error: Tangent space computation needs an UVMap, "(null)" not found, aborting
```

This change ran cleanly and allowed me to achieve what I was after, and I didn't see it in any previously rejected PRs, so I figured I would throw it up here just to see if it was something you considered merge-worthy.