### PR TITLE
Added vertex format 0x8 (3 UVs, no colors)

### DIFF
--- a/wmb/exporter/vertexGroups/vertexGroup.py
+++ b/wmb/exporter/vertexGroups/vertexGroup.py
@@ -64,10 +64,10 @@ class c_vertexGroup(object):
             uv_coords = objOwner.data.uv_layers[uvSlot].data[loopIndex].uv
             return [uv_coords.x, 1-uv_coords.y]
 
-        # Has bones = 7, 10, 11
+        # Has bones = 7, 8, 10, 11
         # 1 UV  = 0
         # 2 UVs = 1, 4, 7, 10
-        # 3 UVs = 5, 11
+        # 3 UVs = 5, 8, 11
         # 4 UVs = 14
         # 5 UVs = 12
         # Has Color = 4, 5, 10, 11, 12, 14
@@ -88,9 +88,12 @@ class c_vertexGroup(object):
                     self.vertexFlags = 1
 
 
-        elif len(self.blenderObjects[0].data.uv_layers) == 3:       # 5, 11
-            if self.blenderObjects[0]['boneSetIndex'] != -1:        # >> 11
-                self.vertexFlags = 11
+        elif len(self.blenderObjects[0].data.uv_layers) == 3:       # 5, 8, 11
+            if self.blenderObjects[0]['boneSetIndex'] != -1:
+                if self.blenderObjects[0].data.vertex_colors:       # >> 11
+                    self.vertexFlags = 11
+                else:                                               # >> 8
+                    self.vertexFlags = 8
             else:                                                   # >> 5
                 self.vertexFlags = 5
 
@@ -107,7 +110,7 @@ class c_vertexGroup(object):
             self.vertexExDataSize = 8       
         elif self.vertexFlags in {5, 7}:                                          
             self.vertexExDataSize = 12                                    
-        elif self.vertexFlags in {10, 14}:
+        elif self.vertexFlags in {8, 10, 14}:
             self.vertexExDataSize = 16
         elif self.vertexFlags in {11, 12}:
             self.vertexExDataSize = 20
@@ -183,7 +186,7 @@ class c_vertexGroup(object):
                     # Bones
                     boneIndexes = []
                     boneWeights = []
-                    if self.vertexFlags in {7, 10, 11}:
+                    if self.vertexFlags in {7, 8, 10, 11}:
                         # Bone Indices
                         for groupRef in bvertex.groups:
                             if len(boneIndexes) < 4:
@@ -256,7 +259,7 @@ class c_vertexGroup(object):
                             print("Object had no vertex colour layer when one was expected - creating one.")
                             new_vertex_colors = bvertex_obj_obj.data.vertex_colors.new()
 
-                    if self.vertexFlags in {1, 4, 5, 7, 10, 11, 12, 14}:
+                    if self.vertexFlags in {1, 4, 5, 7, 8, 10, 11, 12, 14}:
                         normal = [loop.normal[0], loop.normal[1], loop.normal[2], 0]
                     
                     if self.vertexFlags == 5:
@@ -266,6 +269,12 @@ class c_vertexGroup(object):
                     elif self.vertexFlags == 7:
                         uv2 = get_blenderUVCoords(self, bvertex_obj_obj, loop.index, 1)
                         uv_maps.append(uv2)
+
+                    elif self.vertexFlags == 8:
+                        uv2 = get_blenderUVCoords(self, bvertex_obj_obj, loop.index, 1)
+                        uv_maps.append(uv2)
+                        uv3 = get_blenderUVCoords(self, bvertex_obj_obj, loop.index, 1)
+                        uv_maps.append(uv3)
 
                     elif self.vertexFlags == 10:
                         uv2 = get_blenderUVCoords(self, bvertex_obj_obj, loop.index, 1)

--- a/wmb/exporter/write_wmb/wmb_vertexGroups.py
+++ b/wmb/exporter/write_wmb/wmb_vertexGroups.py
@@ -43,7 +43,7 @@ def create_wmb_vertexGroups(wmb_file, data):
                 # for val in vertex[3][1]:                            # UVMap 2
                 #     write_float16(wmb_file, val)
                 writeUV.write(wmb_file, vertex[3][1])
-            if vertexGroup.vertexFlags in {7, 10, 11}:
+            if vertexGroup.vertexFlags in {7, 8, 10, 11}:
                 for val in vertex[4]:                               
                     write_byte(wmb_file, val)                       # Bone Indices
                 for val in vertex[5]:                                   
@@ -73,6 +73,16 @@ def create_wmb_vertexGroups(wmb_file, data):
                 # for val in vertexExData[0]:                         # normal
                 #     write_float16(wmb_file, val)
                 writeNormal.write(wmb_file, vertexExData[0])
+            elif vertexGroup.vertexFlags == 8:                      # [8]
+                # for val in vertexExData[1][0]:                      # UVMap 1
+                #     write_float16(wmb_file, val)
+                writeUV.write(wmb_file, vertexExData[1][0])
+                # for val in vertexExData[0]:                         # normal
+                #     write_float16(wmb_file, val)
+                writeNormal.write(wmb_file, vertexExData[0])
+                # for val in vertexExData[1][1]:                      # UVMap 2
+                #     write_float16(wmb_file, val)
+                writeUV.write(wmb_file, vertexExData[1][1])
             elif vertexGroup.vertexFlags == 10:                     # [10]
                 # for val in vertexExData[1][0]:                      # UVMap 1
                 #     write_float16(wmb_file, val)

--- a/wmb/importer/wmb.py
+++ b/wmb/importer/wmb.py
@@ -119,7 +119,7 @@ class wmb3_vertex(object):
 			# self.textureV2 = read_float16(wmb_fp)
 			self.textureU2, \
 			self.textureV2 = wmb3_vertex.smartReadUV2.read(wmb_fp)
-		if vertex_flags in {7, 10, 11}:
+		if vertex_flags in {7, 8, 10, 11}:
 			self.boneIndices = read_uint8_x4(wmb_fp)
 			self.boneWeights = [x / 255 for x in read_uint8_x4(wmb_fp)]
 		if vertex_flags in {4, 5, 12, 14}:
@@ -135,6 +135,13 @@ class wmb3_vertexExData(object):
 		SmartIO.float16,
 		SmartIO.float16,
 		SmartIO.uint64,
+	)
+	smartRead8 = SmartIO.makeFormat(
+		SmartIO.float16,
+		SmartIO.float16,
+		SmartIO.uint64,
+		SmartIO.float16,
+		SmartIO.float16,
 	)
 	smartRead10 = SmartIO.makeFormat(
 		SmartIO.float16,
@@ -194,6 +201,14 @@ class wmb3_vertexExData(object):
 			self.textureV2 = read_float16(wmb_fp)
 			self.normal = [read_float16(wmb_fp), read_float16(wmb_fp), read_float16(wmb_fp)]
 			dummy = read_float16(wmb_fp)
+
+		elif vertex_flags == 8: #0x8
+			self.textureU2 = read_float16(wmb_fp)				
+			self.textureV2 = read_float16(wmb_fp)
+			self.normal = [read_float16(wmb_fp), read_float16(wmb_fp), read_float16(wmb_fp)]
+			dummy = read_float16(wmb_fp)
+			self.textureU3 = read_float16(wmb_fp)				
+			self.textureV3 = read_float16(wmb_fp)
 
 		elif vertex_flags == 10: #0xa
 			self.textureU2 = read_float16(wmb_fp)				

--- a/wmb/importer/wmb_importer.py
+++ b/wmb/importer/wmb_importer.py
@@ -511,6 +511,7 @@ def format_wmb_mesh(wmb, collection_name, armature):
 			uvMaps[3].append(None)
 			uvMaps[4].append(None)
 
+
 		if vertex_flags in {7, 10}:
 			uv = [(vertex.textureU, 1 - vertex.textureV) for vertex in wmb.vertexGroupArray[vertexGroupIndex].vertexArray]
 			uvMaps[0].append(uv)
@@ -520,7 +521,7 @@ def format_wmb_mesh(wmb, collection_name, armature):
 			uvMaps[3].append(None)
 			uvMaps[4].append(None)
 
-		if vertex_flags == 11:
+		if vertex_flags in {8, 11}:
 			uv = [(vertex.textureU, 1 - vertex.textureV) for vertex in wmb.vertexGroupArray[vertexGroupIndex].vertexArray]
 			uvMaps[0].append(uv)
 			uv = [(vertexExData.textureU2, 1 - vertexExData.textureV2) for vertexExData in wmb.vertexGroupArray[vertexGroupIndex].vertexesExDataArray]


### PR DESCRIPTION
0x8 has weights, 3 UV layers, no vertex colors. Used a lot in Bayonetta 3 (which the plugin is already compatible with for the most part)